### PR TITLE
Fixed typo on landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
                             <br> </p>
                         <li class="graytext">After making your updates, remember to click the <span style="color:white;">"Submit Pull Request"</span> icon in the top right of the page. This will allow you to open a pull request on Github without having to login. </li>
                         <li class="graytext">The <span style="color:white;">Pull Request</span> will be opened on the Github repo. After we've reviewed it and are ready to accept the changes, we'll <span style="color:white;">merge</span> the new content onto the live site!</li>
-                        <li class="graytext"> Because of the review period, you may have to wait a few days for the Pull request to go through. If you have any <a href="https://github.com/DynamoDS/DynamoDictionary/issues" target="_blank">issues</a>, please don't hesitate to log theme <a href="https://github.com/DynamoDS/DynamoDictionary/issues" target="_blank">here.</a></li>
+                        <li class="graytext"> Because of the review period, you may have to wait a few days for the Pull request to go through. If you have any <a href="https://github.com/DynamoDS/DynamoDictionary/issues" target="_blank">issues</a>, please don't hesitate to log them <a href="https://github.com/DynamoDS/DynamoDictionary/issues" target="_blank">here.</a></li>
                         <br>
                         <hr> </body>
             </div>


### PR DESCRIPTION
This is a fix for #116.
I only realized just now that the repo actually contains the HTML of the site as well.
